### PR TITLE
[GitHub Copilot Edits] Add hours_difference method to Post model and corresponding tests

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 class Post < ApplicationRecord
+  # 指定されたDateTimeとcreated_atの時間差を返すメソッド
+  # @param [DateTime] datetime 比較する日時（デフォルトは現在日時）
+  # @return [Float] 時間差（単位：時間）
+  def hours_difference(datetime = DateTime.now)
+    ((datetime - created_at.to_datetime) * 24).to_f
+  end
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -3,7 +3,11 @@
 require 'test_helper'
 
 class PostTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'should return correct hours difference' do
+    post = Post.create!(created_at: 2.hours.ago)
+    assert_in_delta 2.0, post.hours_difference, 0.01
+
+    custom_time = DateTime.now - 3.hours
+    assert_in_delta 1.0, post.hours_difference(custom_time), 0.01
+  end
 end


### PR DESCRIPTION
- Added `hours_difference` method to `Post` model to calculate the difference in hours between `created_at` and a given DateTime (default is current time).
- Added tests for `hours_difference` method in `PostTest`.

model: GPT-4o(GitHub Copilot Edits)

2つ依頼、テストは通らず（現在時刻を利用するためハードルが高いかも）

```
PostモデルにDateTimeを引数で受取り、created_atとの何時間差分があるか返すメソッドを作ってください。引数はデフォルトで現在日時とします YARDでコメントの記載とテストコードを書いてください
```


```
この変更のコミットメッセージを作成してください
```

YARDやテストコードを書くあたりは `copilot-instructions.md` にしてテストし直す
https://docs.github.com/ja/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot