### PR TITLE
[GitHub Copilot Edits GPT-4o] Postモデルにhours_differenceメソッドを追加し、RSpecテストを作成しました

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 class Post < ApplicationRecord
+  # 指定されたDateTimeとcreated_atの時間差を返します
+  # @param [DateTime] datetime 比較する日時、デフォルトは現在日時
+  # @return [Float] 時間差（時間単位）
+  def hours_difference(datetime = DateTime.now)
+    ((datetime - created_at.to_datetime) * 24).to_f
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  # ...existing code...
+
+  describe '#hours_difference' do
+    let(:post) { create(:post, created_at: 2.hours.ago) }
+
+    it 'returns the difference in hours from the given datetime' do
+      expect(post.hours_difference(DateTime.now)).to be_within(0.1).of(2.0)
+    end
+
+    it 'returns the difference in hours from the default datetime (now)' do
+      expect(post.hours_difference).to be_within(0.1).of(2.0)
+    end
+  end
+end


### PR DESCRIPTION
model:GH Copilot Edits GPT-4o

指示
```
PostモデルにDateTimeを引数で受取り、created_atとの何時間差分があるか返すメソッドを作ってください。引数はデフォルトで現在日時とします
```

カスタム指示でYARDコメントなどできた
https://github.com/akinov/sample_rails_for_ai_agent/blob/feature/20250114-gh-copilot-edits-test/.github/copilot-instructions.md


rspec利用していないのにrspecのテストコードを作られてしまった
→カスタム指示でテストコードや規約について伝える必要がある