### PR TITLE
[GitHub Copilot Edits Claud 3.5 Sonnet] Postモデルに時間差分を計算するメソッドを追加

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class Post < ApplicationRecord
+  # @param datetime [DateTime] 比較する日時（デフォルト: 現在日時）
+  # @return [Integer] 指定された日時とcreated_atとの時間差分
+  def time_diff_from(datetime = DateTime.current)
+    ((datetime - created_at) * 24).to_i
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  # ...existing code...
+
+  describe '#time_diff_from' do
+    let(:post) { create(:post, created_at: '2023-01-01 12:00:00') }
+
+    context '引数なしの場合' do
+      it '現在時刻との時間差を返すこと' do
+        travel_to '2023-01-02 12:00:00' do
+          expect(post.time_diff_from).to eq 24
+        end
+      end
+    end
+
+    context '引数ありの場合' do
+      it '指定した日時との時間差を返すこと' do
+        expect(post.time_diff_from(DateTime.parse('2023-01-01 15:00:00'))).to eq 3
+      end
+    end
+  end
+end


### PR DESCRIPTION
- time_diff_fromメソッドを追加
  - 引数の日時とcreated_atの時間差分を計算
  - デフォルトは現在日時との差分
- テストコードを追加

model: GitHub Copilot Edits Claud 3.5 Sonnet

指示
```
PostモデルにDateTimeを引数で受取り、created_atとの何時間差分があるか返すメソッドを作ってください。引数はデフォルトで現在日時とします
```

Rspecになってしまった
travelしているので妥当そうなテストに見える
GPT-4oだと時間操作していなかった
https://github.com/akinov/sample_rails_for_ai_agent/pull/5/files

