### PR TITLE
[GitHub Copilot Workspace] Add hours difference method to Post model

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 class Post < ApplicationRecord
+  # Calculates the difference in hours between the created_at attribute and a given DateTime argument.
+  # @param [DateTime] datetime The DateTime to compare with created_at. Defaults to the current DateTime.
+  # @return [Float] The difference in hours.
+  def hours_difference(datetime = DateTime.now)
+    ((datetime - created_at.to_datetime) * 24).to_f
+  end
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -3,7 +3,11 @@
 require 'test_helper'
 
 class PostTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'hours_difference method' do
+    post = Post.create!(title: 'Test Post', content: 'This is a test post', created_at: DateTime.now - 5.hours)
+
+    assert_in_delta 5.0, post.hours_difference, 0.01
+    assert_in_delta 3.0, post.hours_difference(DateTime.now - 2.hours), 0.01
+    assert_in_delta 7.0, post.hours_difference(DateTime.now + 2.hours), 0.01
+  end
 end


### PR DESCRIPTION
Add `hours_difference` method to `Post` model to calculate the difference in hours between `created_at` and a given DateTime argument.

* Define `hours_difference` method in `Post` model with YARD comments.
* Add test cases in `post_test.rb` to verify the correctness of the `hours_difference` method with different DateTime arguments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akinov/sample_rails_for_ai_agent/pull/7?shareId=1afb8f6f-1dbd-4865-84c4-6d0dc8f441b6).