### PR TITLE
[GitHub Copilot Workspace] Use FormObject in PostsController#create

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -13,36 +13,40 @@ class PostsController < ApplicationController
 
   # GET /posts/new
   def new
-    @post = Post.new
+    @post_form = PostForm.new
   end
 
   # GET /posts/1/edit
-  def edit; end
+  def edit
+    @post_form = PostForm.new(post: @post)
+  end
 
   # POST /posts or /posts.json
   def create
-    @post = Post.new(post_params)
+    @post_form = PostForm.new(post_params)
 
     respond_to do |format|
-      if @post.save
-        format.html { redirect_to @post, notice: 'Post was successfully created.' }
-        format.json { render :show, status: :created, location: @post }
+      if @post_form.save
+        format.html { redirect_to @post_form.post, notice: 'Post was successfully created.' }
+        format.json { render :show, status: :created, location: @post_form.post }
       else
         format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
+        format.json { render json: @post_form.errors, status: :unprocessable_entity }
       end
     end
   end
 
   # PATCH/PUT /posts/1 or /posts/1.json
   def update
+    @post_form = PostForm.new(post_params.merge(post: @post))
+
     respond_to do |format|
-      if @post.update(post_params)
-        format.html { redirect_to @post, notice: 'Post was successfully updated.' }
-        format.json { render :show, status: :ok, location: @post }
+      if @post_form.save
+        format.html { redirect_to @post_form.post, notice: 'Post was successfully updated.' }
+        format.json { render :show, status: :ok, location: @post_form.post }
       else
         format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
+        format.json { render json: @post_form.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -66,6 +70,6 @@ class PostsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def post_params
-    params.require(:post).permit(:title, :content)
+    params.require(:post_form).permit(:title, :content)
   end
 end

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class PostForm < ApplicationForm
+  attr_accessor :title, :content, :post
+
+  validates :title, presence: true
+  validates :content, presence: true
+
+  def initialize(attributes = {})
+    @post = attributes[:post]
+    super(attributes)
+  end
+
+  def save
+    return false unless valid?
+
+    @post ||= Post.new
+    @post.assign_attributes(title: title, content: content)
+    @post.save
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationForm
+  include ActiveModel::Model
+end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,10 +1,10 @@
-<%= form_with(model: post) do |form| %>
-  <% if post.errors.any? %>
+<%= form_with(model: post_form) do |form| %>
+  <% if post_form.errors.any? %>
     <div style="color: red">
-      <h2><%= pluralize(post.errors.count, "error") %> prohibited this post from being saved:</h2>
+      <h2><%= pluralize(post_form.errors.count, "error") %> prohibited this post from being saved:</h2>
 
       <ul>
-        <% post.errors.each do |error| %>
+        <% post_form.errors.each do |error| %>
           <li><%= error.full_message %></li>
         <% end %>
       </ul>

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -19,7 +19,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should create post' do
     assert_difference('Post.count') do
-      post posts_url, params: { post: { content: @post.content, title: @post.title } }
+      post posts_url, params: { post_form: { content: @post.content, title: @post.title } }
     end
 
     assert_redirected_to post_url(Post.last)
@@ -36,7 +36,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update post' do
-    patch post_url(@post), params: { post: { content: @post.content, title: @post.title } }
+    patch post_url(@post), params: { post_form: { content: @post.content, title: @post.title } }
     assert_redirected_to post_url(@post)
   end
 

--- a/test/forms/post_form_test.rb
+++ b/test/forms/post_form_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PostFormTest < ActiveSupport::TestCase
+  def setup
+    @post_form = PostForm.new(title: 'Test Title', content: 'Test Content')
+  end
+
+  test 'should be valid with valid attributes' do
+    assert @post_form.valid?
+  end
+
+  test 'should be invalid without a title' do
+    @post_form.title = nil
+    assert_not @post_form.valid?
+    assert_includes @post_form.errors[:title], "can't be blank"
+  end
+
+  test 'should be invalid without content' do
+    @post_form.content = nil
+    assert_not @post_form.valid?
+    assert_includes @post_form.errors[:content], "can't be blank"
+  end
+
+  test 'should save post with valid attributes' do
+    assert_difference('Post.count') do
+      assert @post_form.save
+    end
+  end
+
+  test 'should not save post with invalid attributes' do
+    @post_form.title = nil
+    assert_no_difference('Post.count') do
+      assert_not @post_form.save
+    end
+  end
+end


### PR DESCRIPTION
Modify the `PostsController` to use `PostForm` FormObject for creating and updating posts.

* **Controller Changes**
  - Update `new` action to initialize `PostForm` instead of `Post`.
  - Update `edit` action to initialize `PostForm` with the existing post.
  - Modify `create` action to use `PostForm` for creating a new post.
  - Modify `update` action to use `PostForm` for updating an existing post.
  - Update `post_params` method to permit `post_form` parameters.

* **Form Object**
  - Add `PostForm` class inheriting from `ApplicationForm`.
  - Define attributes `title`, `content`, and `post` with `attr_accessor`.
  - Add validations for `title` and `content`.
  - Implement `save` method to handle saving the `Post` model.

* **Application Form**
  - Add `ApplicationForm` class including `ActiveModel::Model`.

* **View Changes**
  - Update `_form.html.erb` to use `post_form` instead of `post`.
  - Update form fields to use `post_form` attributes.

* **Tests**
  - Add `PostForm` tests for validations and `save` method.
  - Update `PostsController` tests to use `PostForm` instead of `Post`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akinov/sample_rails_for_ai_agent/pull/8?shareId=70186c6c-90b3-407e-a3fd-e2cc03b1d56f).